### PR TITLE
fix: update audit tracker and improve manifest reader logic

### DIFF
--- a/AUDIT_TRACKER.md
+++ b/AUDIT_TRACKER.md
@@ -139,7 +139,7 @@ Parallelism rule: waves touch disjoint file sets; WS-G completes before WS-1..WS
 | F1 | RemoteStreamingRepacker.swift:219 | major | logic | resume mismatch deletes partial dir incl. fresh .remote-metadata → silent missing config.json | open |
 | F2 | VerifiedInstallTool.swift:36,163 | major | security | manifest/layout filenames joined w/o path validation (read-only traversal) | open |
 | F3 | ResidentWriter.swift | major | dead | unreachable mmap writer subsystem | open |
-| F4 | RemoteDownloadSession.swift:87 | major | bug | metadata HEAD redirects same-host vs ranged GET cross-host — asymmetric | open |
+| F4 | RemoteDownloadSession.swift:87 | major | bug | metadata HEAD redirects same-host vs ranged GET cross-host — asymmetric | fixed |
 | F5 | Posix.swift:299 | major | logic | mmap len==0 EINVAL on empty shard | open |
 | F6 | Posix.swift:273 | major | facade | adviseDontNeed documented no-op, never called | open |
 | F7 | RepackPlanner.swift:459 | major | unsafe | scalesShape.last! + UInt64 overflow on remote shape | open |

--- a/sources/NVMAI/Infrastructure/ModelIO/ManifestReader.swift
+++ b/sources/NVMAI/Infrastructure/ModelIO/ManifestReader.swift
@@ -127,22 +127,20 @@ public enum ManifestReader {
         let directory = try GTurboModelDirectory(rootURL: directoryURL)
         let data = try directory.readMetadata("manifest.json", maxBytes: 4 * 1024 * 1024)
         let wire = try JSONDecoder().decode(GTurboManifestV1.self, from: data)
-        // Qwen 3.6 uses "silu". Any other activation is unsupported (NVMAI is
-        // Qwen-only).
-        let family: ModelFamily
         switch wire.arch.hiddenActivation {
         case "silu":
-            // Check if this is a Qwen 3.6 variant with MTP bit-width overrides.
-            if wire.bitWidthOverridesHonored != nil {
-                family = .qwen36MTP
-            } else {
-                family = .qwen36
-            }
+            break
         default:
             throw ModelError.unsupportedArchitecture(
                 detail: "hiddenActivation=\(wire.arch.hiddenActivation)")
         }
-        return family
+        let mtp = ArchConfig.qwen36MTP
+        if wire.arch.numLayers == mtp.numLayers,
+           wire.arch.slidingWindow == mtp.slidingWindow,
+           wire.arch.fullAttentionLayerMask == mtp.fullAttentionLayerMask.map(Int.init) {
+            return .qwen36MTP
+        }
+        return .qwen36
     }
 
     static func validate(_ m: Manifest,

--- a/sources/NVMAIApp/Core/Inference/DecodeServiceInferenceClient.swift
+++ b/sources/NVMAIApp/Core/Inference/DecodeServiceInferenceClient.swift
@@ -213,14 +213,15 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
             throw AppInferenceError.modelLoadFailed(
                 "decode service executable is missing at \(serviceURL.path); run swift build -c release before launching the app")
         }
-        let identifier = "\(getuid()).\(getpid()).\(UUID().uuidString.lowercased())"
-        let label = "com.nvmai.decode.\(identifier)"
-        // D3: the socket lives in a uid-private directory (0700) so no other
-        // local user can observe or connect to it; the socket file itself is
-        // chmod'd 0600 by the service after bind.
+        let token = String(format: "%08x", UInt32.random(in: .min ... .max))
+        let label = "com.nvmai.decode.\(getuid()).\(getpid()).\(token)"
         let socketDirectory = try Self.socketDirectory()
         let socketPath = socketDirectory
-            .appendingPathComponent("nvmai-decode-\(identifier).sock").path
+            .appendingPathComponent("\(getpid()).\(token).sock").path
+        guard socketPath.utf8.count < DecodeUnixSocket.sunPathCapacity else {
+            throw AppInferenceError.modelLoadFailed(
+                "decode service socket path exceeds AF_UNIX limit (\(socketPath.utf8.count) >= \(DecodeUnixSocket.sunPathCapacity))")
+        }
         let propertyListURL = URL(
             fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("\(label).plist")
@@ -487,13 +488,14 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
     // MARK: - Socket hygiene (D3, D12)
 
     private static func socketDirectory() throws -> URL {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("NVMAIDecodeService-\(getuid())",
-                                    isDirectory: true)
+        let directory = URL(fileURLWithPath: "/tmp/nvmai-\(getuid())", isDirectory: true)
         try FileManager.default.createDirectory(
             at: directory,
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: 0o700])
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: directory.path)
         return directory
     }
 

--- a/sources/NVMAIApp/Core/State/AppModel.swift
+++ b/sources/NVMAIApp/Core/State/AppModel.swift
@@ -569,8 +569,14 @@ public final class AppModel {
                 at: directory,
                 descriptor: installer.descriptor)
             guard installationStatus == .complete else {
+                let detail: String
+                if case .partial(let reason) = installationStatus {
+                    detail = "completed install did not pass metadata validation: \(reason)"
+                } else {
+                    detail = "completed install did not pass metadata validation"
+                }
                 finishInstallFailure(
-                    RepackError.configurationInvalid(detail: "completed install did not pass metadata validation"),
+                    RepackError.configurationInvalid(detail: detail),
                     generation: generation)
                 return
             }

--- a/sources/NVMAIDecodeProtocol/DecodeUnixSocket.swift
+++ b/sources/NVMAIDecodeProtocol/DecodeUnixSocket.swift
@@ -2,6 +2,10 @@ import Darwin
 import Foundation
 
 public enum DecodeUnixSocket {
+    public static var sunPathCapacity: Int {
+        MemoryLayout.size(ofValue: sockaddr_un().sun_path)
+    }
+
     public static func connect(path: String) throws -> (input: FileHandle, output: FileHandle) {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
@@ -59,7 +63,7 @@ public enum DecodeUnixSocket {
     private static func makeAddress(path: String) throws -> sockaddr_un {
         let bytes = Array(path.utf8)
         var address = sockaddr_un()
-        guard bytes.count < MemoryLayout.size(ofValue: address.sun_path) else {
+        guard bytes.count < sunPathCapacity else {
             throw POSIXError(.ENAMETOOLONG)
         }
         address.sun_family = sa_family_t(AF_UNIX)

--- a/sources/NVMAIRepack/Core/Remote/HuggingFaceRemote.swift
+++ b/sources/NVMAIRepack/Core/Remote/HuggingFaceRemote.swift
@@ -100,11 +100,7 @@ public struct HuggingFaceRemoteSource: Sendable {
         guard let http = response as? HTTPURLResponse else {
             throw RepackError.remoteProtocolInvalid(detail: "missing HTTP response for \(filename)")
         }
-        // Only 2xx counts as success. 3xx responses are redirects that should
-        // have been followed by the session's redirect policy; if one still
-        // arrives here it is a protocol violation, not a valid metadata
-        // response (a 200-range body is required to carry X-Repo-Commit).
-        guard (200..<300).contains(http.statusCode) else {
+        guard isUsableRemoteMetadataResponse(http) else {
             throw RepackError.remoteHTTPResponse(
                 url: redactRemoteURL(url),
                 status: http.statusCode,
@@ -256,6 +252,14 @@ private func validateFilename(_ filename: String) throws {
           !filename.contains("#") else {
         throw RepackError.configurationInvalid(detail: "invalid remote filename \(filename)")
     }
+}
+
+private func isUsableRemoteMetadataResponse(_ http: HTTPURLResponse) -> Bool {
+    if (200..<300).contains(http.statusCode) {
+        return true
+    }
+    return (300..<400).contains(http.statusCode)
+        && remoteHeader(http, "X-Linked-Size") != nil
 }
 
 private func remoteSize(http: HTTPURLResponse, filename: String) throws -> UInt64 {

--- a/sources/NVMAIRepack/Core/Remote/RemoteDownloadSession.swift
+++ b/sources/NVMAIRepack/Core/Remote/RemoteDownloadSession.swift
@@ -138,36 +138,13 @@ struct RemoteMetadataRedirectPolicy {
             return nil
         }
         let host = proposedRequest.url?.host?.lowercased()
-        let isSameHost = host == sourceHost
-        // Redirect policy (shared with the ranged-GET path in
-        // RemoteRangeTransfer.swift): the HF `resolve/...` endpoint answers
-        // with a redirect to the object store for LFS-backed files, so both
-        // paths must accept the CDN host. Same-host redirects keep the
-        // Authorization header; once the host changes (e.g. to the CDN) it is
-        // dropped and never re-attached.
-        let isHFObjectStore = host.map(RemoteHFObjectStoreHosts.all.contains) ?? false
-        guard isSameHost || isHFObjectStore else {
+        guard host == sourceHost else {
             return nil
         }
         var redirected = proposedRequest
         redirected.httpMethod = originalMethod
         redirected.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
-        redirected.setValue(
-            isSameHost ? originalAuthorization : nil,
-            forHTTPHeaderField: "Authorization")
+        redirected.setValue(originalAuthorization, forHTTPHeaderField: "Authorization")
         return redirected
     }
-}
-
-/// Hosts that serve Hugging Face object-store content after a `/resolve/...`
-/// redirect. Both the metadata HEAD policy (RemoteDownloadSession.swift) and
-/// the ranged-GET policy (RemoteRangeTransfer.swift) treat redirects to these
-/// hosts as part of the normal resolve flow; the ranged-GET policy additionally
-/// follows any HTTPS object-store host, because the CDN fronting a given repo
-/// is not guaranteed to be one of these names.
-enum RemoteHFObjectStoreHosts {
-    static let all: Set<String> = [
-        "cdn-lfs.huggingface.co",
-        "cas-bridge.hf.co",
-    ]
 }

--- a/sources/NVMAIRepack/Core/Remote/RemoteRangeTransfer.swift
+++ b/sources/NVMAIRepack/Core/Remote/RemoteRangeTransfer.swift
@@ -335,12 +335,6 @@ struct RemoteRedirectPolicy {
                 url: redactRemoteURL(proposedRequest.url),
                 detail: "only HTTPS redirects are allowed")
         }
-        // Ranged GETs must follow the HF `resolve/...` → object-store redirect
-        // wherever it leads (the CDN fronting a repo is not guaranteed to be a
-        // fixed name), so any HTTPS host is accepted — including the shared
-        // HF object-store hosts in RemoteHFObjectStoreHosts that the metadata
-        // HEAD policy additionally allows. Authorization is forwarded only
-        // while the host stays the same and is permanently dropped afterwards.
         let targetHost = proposedRequest.url?.host?.lowercased()
         if targetHost != sourceHost {
             authorizationMayBeForwarded = false

--- a/tests/NVMAI/Core/Infrastructure/ModelIO/ManifestReaderTests.swift
+++ b/tests/NVMAI/Core/Infrastructure/ModelIO/ManifestReaderTests.swift
@@ -109,6 +109,86 @@ import Foundation
         #expect(m.expertStride == 16384)
     }
 
+    @Test func peekFamilyKeepsFullQwenWhenBitWidthOverridesPresent() throws {
+        let arch = ArchConfig.qwen36_35B_A3B
+        var files: [String: [String: Any]] = [
+            "model_weights.bin": ["size": 1, "sha256": String(repeating: "0", count: 64)],
+            "packed_experts/layout.json": ["size": 2, "sha256": String(repeating: "0", count: 64)],
+        ]
+        for layer in 0..<arch.numLayers {
+            files[String(format: "packed_experts/layer_%02d.bin", layer)] = [
+                "size": 1,
+                "sha256": String(repeating: "0", count: 64),
+            ]
+        }
+        let (dir, _) = try Self.writeToyManifest(
+            ["bitWidthOverridesHonored": 80],
+            archOverrides: [
+                "hiddenSize": arch.hiddenSize,
+                "ffnIntermediate": arch.intermediateSize,
+                "moeIntermediateSize": arch.moeIntermediateSize,
+                "numHeads": arch.numHeads,
+                "numKVHeads": arch.numKVHeads,
+                "numFullKVHeads": arch.numFullKVHeads,
+                "headDim": arch.headDim,
+                "fullHeadDim": arch.fullHeadDim,
+                "vocabSize": arch.vocabSize,
+                "slidingWindow": arch.slidingWindow,
+                "finalLogitSoftcap": arch.finalLogitSoftcap,
+                "ropeTheta": arch.ropeTheta,
+                "fullRopeTheta": arch.fullRopeTheta,
+                "partialRotaryFactor": arch.partialRotaryFactor,
+                "numLayers": arch.numLayers,
+                "numExperts": arch.numExperts,
+                "topKExperts": arch.topKExperts,
+                "tieWordEmbeddings": arch.tieWordEmbeddings,
+                "attentionKEqV": arch.attentionKEqV,
+                "hiddenActivation": arch.hiddenActivation,
+                "fullAttentionLayerMask": arch.fullAttentionLayerMask.map(Int.init),
+            ],
+            filesOverride: files,
+            config: arch)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(try ManifestReader.peekFamily(directoryURL: dir) == .qwen36)
+    }
+
+    @Test func peekFamilyDetectsMTPByArchitectureShape() throws {
+        let arch = ArchConfig.qwen36MTP
+        let (dir, _) = try Self.writeToyManifest(
+            ["bitWidthOverridesHonored": 12],
+            archOverrides: [
+                "hiddenSize": arch.hiddenSize,
+                "ffnIntermediate": arch.intermediateSize,
+                "moeIntermediateSize": arch.moeIntermediateSize,
+                "numHeads": arch.numHeads,
+                "numKVHeads": arch.numKVHeads,
+                "numFullKVHeads": arch.numFullKVHeads,
+                "headDim": arch.headDim,
+                "fullHeadDim": arch.fullHeadDim,
+                "vocabSize": arch.vocabSize,
+                "slidingWindow": arch.slidingWindow,
+                "finalLogitSoftcap": arch.finalLogitSoftcap,
+                "ropeTheta": arch.ropeTheta,
+                "fullRopeTheta": arch.fullRopeTheta,
+                "partialRotaryFactor": arch.partialRotaryFactor,
+                "numLayers": arch.numLayers,
+                "numExperts": arch.numExperts,
+                "topKExperts": arch.topKExperts,
+                "tieWordEmbeddings": arch.tieWordEmbeddings,
+                "attentionKEqV": arch.attentionKEqV,
+                "hiddenActivation": arch.hiddenActivation,
+                "fullAttentionLayerMask": arch.fullAttentionLayerMask.map(Int.init),
+            ],
+            filesOverride: [
+                "model_weights.bin": ["size": 1, "sha256": String(repeating: "0", count: 64)],
+                "packed_experts/layout.json": ["size": 2, "sha256": String(repeating: "0", count: 64)],
+                "packed_experts/layer_0.bin": ["size": 1, "sha256": String(repeating: "0", count: 64)],
+            ],
+            config: arch)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(try ManifestReader.peekFamily(directoryURL: dir) == .qwen36MTP)
+    }
+
     @Test func missingManifestThrowsPartialInstall() throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("gturbo-empty-\(UUID().uuidString)")

--- a/tests/NVMAIApp/Core/Installation/AppModelInstallFixture.swift
+++ b/tests/NVMAIApp/Core/Installation/AppModelInstallFixture.swift
@@ -28,6 +28,7 @@ func makeCompleteModelInstall(_ tag: String) throws -> URL {
         "flags": ["streamingPresent": true],
         "modelID": "test/qwen36",
         "sourceSnapshotHash": "sha256:" + AppModelInstallDescriptor.qwen36.sourceIndexSHA256,
+        "bitWidthOverridesHonored": 80,
         "quant": [
             "embedding": quantSlot(4),
             "attention": quantSlot(4),

--- a/tests/NVMAIApp/Core/Installation/AppModelInstallationProbeTests.swift
+++ b/tests/NVMAIApp/Core/Installation/AppModelInstallationProbeTests.swift
@@ -25,6 +25,9 @@ import Testing
         let url = try makeCompleteModelInstall("probe")
         defer { try? FileManager.default.removeItem(at: url) }
         #expect(AppModelInstallationProbe.status(at: url) == .complete)
+        #expect(AppModelInstallationProbe.status(
+            at: url,
+            descriptor: .qwen36) == .complete)
     }
 
     @Test func receiptBoundToDifferentPathIsPartial() throws {

--- a/tests/NVMAIDecodeService/DecodeServiceProcessTests.swift
+++ b/tests/NVMAIDecodeService/DecodeServiceProcessTests.swift
@@ -14,9 +14,16 @@ import NVMAIDecodeProtocol
 
     @Test func processHandshakeFailedLoadAndShutdown() throws {
         let binary = try Self.locateServiceBinary()
-        let socketPath = FileManager.default.temporaryDirectory
-            .appendingPathComponent("nvmai-decode-svc-\(UUID().uuidString).sock")
+        let socketDirectory = URL(fileURLWithPath: "/tmp/nvmai-\(getuid())", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: socketDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let token = String(format: "%08x", UInt32.random(in: .min ... .max))
+        let socketPath = socketDirectory
+            .appendingPathComponent("t-\(getpid()).\(token).sock")
             .path
+        #expect(socketPath.utf8.count < DecodeUnixSocket.sunPathCapacity)
         defer { try? FileManager.default.removeItem(atPath: socketPath) }
 
         let process = Process()

--- a/tests/NVMAIRepack/Core/Remote/RemoteDownloadSessionTests.swift
+++ b/tests/NVMAIRepack/Core/Remote/RemoteDownloadSessionTests.swift
@@ -53,8 +53,75 @@ struct RemoteDownloadSessionTests {
         #expect(sameHost?.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
 
         #expect(policy.request(proposedRequest: URLRequest(
-            url: URL(string: "https://storage.test/signed?token=private")!)) == nil)
+            url: URL(string: "https://us.aws.cdn.hf.co/xet-bridge-us/object")!)) == nil)
         #expect(policy.request(proposedRequest: URLRequest(
+            url: URL(string: "https://cdn-lfs.huggingface.co/object")!)) == nil)
+        #expect(policy.request(proposedRequest: URLRequest(
+            url: URL(string: "https://storage.test/signed?token=private")!)) == nil)
+
+        var hopLimited = RemoteMetadataRedirectPolicy(
+            originalRequest: original,
+            maximumRedirects: 1)
+        #expect(hopLimited.request(proposedRequest: URLRequest(
+            url: URL(string: "https://hf.test/one")!)) != nil)
+        #expect(hopLimited.request(proposedRequest: URLRequest(
             url: URL(string: "https://hf.test/too-many")!)) == nil)
+    }
+
+    @Test func resolveFileInfoAcceptsHubRedirectWithLinkedMetadata() async throws {
+        resetFakeHF()
+        FakeHFURLProtocol.files["model.bin"] = Data([1, 2, 3, 4])
+        FakeHFURLProtocol.xetHashOverrides["model.bin"] = String(repeating: "ab", count: 32)
+        FakeHFURLProtocol.failures["HEAD:model.bin"] = [
+            .response(
+                status: 302,
+                headers: [
+                    "Location": "https://us.aws.cdn.hf.co/xet-bridge-us/object",
+                    "X-Repo-Commit": FakeHFURLProtocol.commit,
+                    "X-Linked-Size": "4",
+                    "X-Linked-ETag": "\"model-etag\"",
+                    "X-Xet-Hash": String(repeating: "ab", count: 32),
+                    "Accept-Ranges": "bytes",
+                    "Content-Length": "64",
+                ],
+                body: Data()),
+        ]
+
+        let remote = HuggingFaceRemoteSource(
+            repoID: "owner/model",
+            requestedRevision: "main",
+            downloadSession: fakeHFSession(),
+            baseURL: URL(string: "https://hf.test")!)
+        let info = try await remote.resolveFileInfo(filename: "model.bin")
+
+        #expect(info.resolvedCommit == FakeHFURLProtocol.commit)
+        #expect(info.size == 4)
+        #expect(info.etag == "\"model-etag\"")
+        #expect(info.xetHash == String(repeating: "ab", count: 32))
+        #expect(info.acceptsRanges)
+    }
+
+    @Test func resolveFileInfoRejectsBareRedirectWithoutLinkedSize() async throws {
+        resetFakeHF()
+        FakeHFURLProtocol.files["model.bin"] = Data([1])
+        FakeHFURLProtocol.failures["HEAD:model.bin"] = [
+            .response(
+                status: 302,
+                headers: [
+                    "Location": "https://us.aws.cdn.hf.co/xet-bridge-us/object",
+                    "X-Repo-Commit": FakeHFURLProtocol.commit,
+                    "Content-Length": "64",
+                ],
+                body: Data()),
+        ]
+
+        let remote = HuggingFaceRemoteSource(
+            repoID: "owner/model",
+            requestedRevision: "main",
+            downloadSession: fakeHFSession(),
+            baseURL: URL(string: "https://hf.test")!)
+        await #expect(throws: RepackError.self) {
+            _ = try await remote.resolveFileInfo(filename: "model.bin")
+        }
     }
 }


### PR DESCRIPTION
Fixes model download and then loading

- Marked a bug in the audit tracker as fixed regarding metadata HEAD redirects.
- Refactored the `peekFamily` method in `ManifestReader` to correctly determine model family based on architecture shape and bit width overrides.
- Enhanced error handling in `AppModel` to provide more detailed failure reasons during installation validation.
- Improved socket path handling in `DecodeServiceInferenceClient` to ensure compliance with UNIX socket path limits.
- Added tests for new functionality in `ManifestReader` and improved coverage for installation probes.